### PR TITLE
Fix issue for incorrectly rotated images after resizing

### DIFF
--- a/jekyll-resize.gemspec
+++ b/jekyll-resize.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'jekyll-resize'
-  s.version     = '1.3.0'
+  s.version     = '1.3.1'
   s.date        = '2021-11-21'
   s.summary     = 'Liquid filter to resize images in Jekyll 3 and 4'
   s.description = ''

--- a/lib/jekyll-resize.rb
+++ b/lib/jekyll-resize.rb
@@ -40,8 +40,9 @@ module Jekyll
     def _process_img(src_path, options, dest_path)
       image = MiniMagick::Image.open(src_path)
 
-      image.strip
+      image.auto_orient
       image.resize options
+      image.strip
 
       image.write dest_path
     end


### PR DESCRIPTION
This plugin currently results in an issue with some images that are vertical, where after resizing, they will be incorrectly rotated. This is due to the fact that the image metadata is being stripped before resizing.

This change calls auto orient to ensure the image is correctly rotated using the metadata, and that the stripping is done after the rotation instead of before.