### PR TITLE
Allow image format to be changed

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -62,6 +62,24 @@ image_path: assets/img/hello.jpg
 <img src="{{ page.image_path | resize: '800x800>' | relative_url }}" alt="My image" />
 ```
 
+### Changing file format
+
+If you want to output thumbnails in a different file format, you can pass a format option:
+
+```liquid
+---
+image_path: assets/img/hello.jpg
+---
+
+<img src="{{ page.image_path | resize: '800x800> format: png' | relative_url }}" alt="My image" />
+```
+
+This will create the resized image as a PNG, and produce the following output:
+
+```
+<img src="/my-repo-name/cache/resize/abcdefgh123_800x800.png" alt="My image" />
+```
+
 
 ## Building
 

--- a/lib/jekyll-resize.rb
+++ b/lib/jekyll-resize.rb
@@ -11,7 +11,12 @@ module Jekyll
       hash = Digest::SHA256.file(src_path)
       short_hash = hash.hexdigest()[0, HASH_LENGTH]
       options_slug = options.gsub(/[^\da-z]+/i, "")
+
       ext = File.extname(src_path)
+      # If we've been told to override the file format, do so here.
+      /\s+format:\s*(\w+)/.match(options) do |match|
+        ext = "." + match[1]
+      end
 
       "#{short_hash}_#{options_slug}#{ext}"
     end
@@ -40,6 +45,9 @@ module Jekyll
     def _process_img(src_path, options, dest_path)
       image = MiniMagick::Image.open(src_path)
 
+      # Strip any non-ImageMagick options
+      options = options.gsub(/\s*\w+:\s*\w+\s*/, "")
+
       image.auto_orient
       image.resize options
       image.strip
@@ -50,7 +58,7 @@ module Jekyll
     # Liquid tag entry-point.
     #
     # param source: e.g. "my-image.jpg"
-    # param options: e.g. "800x800>"
+    # param options: e.g. "800x800>", "small format:jpg"
     #
     # return dest_path_rel: Relative path for output file.
     def resize(source, options)


### PR DESCRIPTION
Hello,

I use jekyll-resize to, among other things, generate Twitter card images for posts. But Twitter cards don't accept AVIF images, only JPEG/PNG/WebP, which is a bit rubbish because AVIFs are great.

This change allows me to pass e.g. "format: jpg" in the options string, along with their image size, in order to control the file format that Mini Magick outputs.

For example:

```
<meta name="twitter:image" content="{{ page.featured_image | sized_image: "1000x1000> format:jpg" | absolute_url }}">
```